### PR TITLE
18 destroy commitments

### DIFF
--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -6,7 +6,7 @@ class CommitmentsController < ApplicationController
     filters: []
   }.to_json
 
-  before_action :set_commitment, only: [:show, :edit, :update]
+  before_action :set_commitment, only: [:show, :edit, :update, :destroy]
 
   def index
     @paginatedCommitments = Commitment.paginate_commitments(DEFAULT_PARAMS).to_json
@@ -63,6 +63,18 @@ class CommitmentsController < ApplicationController
     if @commitment.update(commitment_params)
       respond_to do |format|
         format.json { json_response({ commitment: @commitment }, 204) }
+      end
+    else
+      respond_to do |format|
+        format.json { json_response({ errors: @commitment.errors }, :unprocessable_entity) }
+      end
+    end
+  end
+
+  def destroy
+    if @commitment.destroy
+      respond_to do |format|
+        format.json { json_response({}, 204) }
       end
     else
       respond_to do |format|

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -19,9 +19,9 @@ class Commitment < ApplicationRecord
   import_by actions: :name
   has_and_belongs_to_many :threats
   import_by threats: :name
-  has_many :links
+  has_many :links, dependent: :destroy
   import_by links: :url
-  has_many :progress_documents
+  has_many :progress_documents, dependent: :destroy
   has_one_attached :geospatial_file
 
   belongs_to :criterium, optional: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get '/', to: 'home#index'
 
 
-  resources :commitments, only: [:show, :index, :new, :create, :edit, :update]
+  resources :commitments
   post '/commitments/list', to: 'commitments#list'
 
   resources :criteria, only: [:new, :create]

--- a/test/controllers/commitments_controller_test.rb
+++ b/test/controllers/commitments_controller_test.rb
@@ -111,4 +111,12 @@ class CommitmentsControllerTest < ActionDispatch::IntegrationTest
     assert_response 204
     assert commitment.reload.description == new_description
   end
+
+  test "should destroy a commitment" do
+    commitment_count_at_start = Commitment.count
+    commitment = commitments(:valid_commitment_1)
+    delete commitment_url(commitment), as: :json
+    assert_response 204
+    assert Commitment.count == commitment_count_at_start - 1
+  end
 end


### PR DESCRIPTION
# Testing

## Rails

`rails test test/controllers/commitments_controller_test.rb`

## Postman/HTTP

1. add `skip_forgery_protection` to ApplicationController
2. send a DELETE request to localhost:3000/commitments/1 (making sure the database is seeded/imported first)