### PR TITLE
Added scope so we can only return the required form options in the co…

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -4,6 +4,8 @@ class Action < ApplicationRecord
     'Law & policy', 'Livelihood', 'Economic & other incentives' , 'Other'
   ]
 
+  scope :commitment_form_options, -> { where(default_option: true) }
+
   has_and_belongs_to_many :commitments
   
   validates_presence_of :name

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -4,6 +4,8 @@ class Manager < ApplicationRecord
     'Collaborative governance', 'Joint governance', 'Sub-national ministry or agency', 'Other'
   ]
 
+  scope :commitment_form_options, -> { where(default_option: true) }
+
   has_and_belongs_to_many :commitments
   
   validates_presence_of :name

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -5,6 +5,8 @@ class Objective < ApplicationRecord
     'Preservation of traditional livelihoods', 'Certification of products', 'Recreation', 'Academic research'
   ]
 
+  scope :commitment_form_options, -> { where(default_option: true) }
+  
   has_and_belongs_to_many :commitments
 
   validates_presence_of :name

--- a/app/models/services/commitment_props.rb
+++ b/app/models/services/commitment_props.rb
@@ -52,7 +52,7 @@ class Services::CommitmentProps
                 title: I18n.t('form.commitments.page1.q3.title'),
                 description: I18n.t('form.commitments.page1.q3.description'),
                 defaultValue: @commitment.objective_ids || [],
-                choices: Objective.pluck(:id, :name).map do |id, name|
+                choices: Objective.commitment_form_options.pluck(:id, :name).map do |id, name|
                           if name != 'None of the above'
                             {
                               value: id,
@@ -69,7 +69,7 @@ class Services::CommitmentProps
                 title: I18n.t('form.commitments.page1.q4.title'),
                 description: I18n.t('form.commitments.page1.q3.description'),
                 defaultValue: @commitment.manager_ids || [],
-                choices: Manager.pluck(:id, :name).map do |id, name|
+                choices: Manager.commitment_form_options.pluck(:id, :name).map do |id, name|
                           if name != 'None of the above'
                             {
                               value: id,
@@ -193,7 +193,7 @@ class Services::CommitmentProps
                 title: I18n.t('form.commitments.page4.q2.title'),
                 description: I18n.t('form.commitments.page4.q2.description'),
                 defaultValue: @commitment.action_ids || [],
-                choices: Action.pluck(:id, :name).map do |id, name|
+                choices: Action.commitment_form_options.pluck(:id, :name).map do |id, name|
                           if name != 'None of the above'
                             {
                               value: id,
@@ -218,7 +218,7 @@ class Services::CommitmentProps
                 title: I18n.t('form.commitments.page4.q4.title'),
                 description: I18n.t('form.commitments.page4.q4.description'),
                 defaultValue: @commitment.threat_ids || [],
-                choices: Threat.pluck(:id, :name).map do |id, name|
+                choices: Threat.commitment_form_options.pluck(:id, :name).map do |id, name|
                           if name != 'None of the above'
                             {
                               value: id,

--- a/app/models/threat.rb
+++ b/app/models/threat.rb
@@ -5,6 +5,8 @@ class Threat < ApplicationRecord
     'Genes & diseases', 'Pollution', 'Geological events', 'Climate change & severe weather', 'Other'
   ]
 
+  scope :commitment_form_options, -> { where(default_option: true) }
+  
   has_and_belongs_to_many :commitments
   
   validates_presence_of :name


### PR DESCRIPTION
Added scope so we can only return the required form options in the commitment form, and not options added via the csv and cbd imports