### PR TITLE
Added errors when there are progress notes but no signed_id

### DIFF
--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -9,6 +9,7 @@ class CommitmentsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :list, :show]
   before_action :set_commitment, only: [:show, :edit, :update, :destroy]
   before_action :purge_geospatial_file, only: [:update, :create]
+  before_action :clean_progress_document_attachment_params, only: [:update, :create]
 
   def index
     @paginatedCommitments = Commitment.paginate_commitments(DEFAULT_PARAMS).to_json
@@ -95,6 +96,25 @@ class CommitmentsController < ApplicationController
     if commitment_params[:geospatial_file].blank?
       params[:commitment] = params[:commitment].except(:geospatial_file)
       @commitment.geospatial_file.purge if @commitment && @commitment.geospatial_file.attached?
+    end
+  end
+
+  def clean_progress_document_attachment_params
+    new_progress_document_attributes = []
+    invalid_progress_document_attributes = []
+
+    commitment_params[:progress_documents_attributes].each do |progress_document_attributes|
+      if progress_document_attributes[:document].present?
+        new_progress_document_attributes << progress_document_attributes
+      elsif progress_document_attributes[:progress_notes].present?
+        invalid_progress_document_attributes << progress_document_attributes
+      end
+    end
+
+    if invalid_progress_document_attributes.present?
+      raise MissingProgressDocumentAttachmentError
+    else
+      commitment_params[:progress_documents_attributes] = new_progress_document_attributes
     end
   end
 

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -2,6 +2,7 @@ module ExceptionHandler
   extend ActiveSupport::Concern
 
   class ForbiddenError < StandardError; end
+  class MissingProgressDocumentAttachmentError < StandardError; end
 
   included do
     rescue_from ActiveRecord::RecordNotFound do |e|
@@ -22,6 +23,12 @@ module ExceptionHandler
       respond_to do |format|
         format.json { json_response({ message: I18n.t('errors.messages.forbidden_resource') }, :forbidden) }
         format.html { redirect_back fallback_location: root_path, notice: I18n.t('errors.messages.forbidden_resource') }
+      end
+    end
+
+    rescue_from MissingProgressDocumentAttachmentError do |e|
+      respond_to do |format|
+        format.json { json_response({ errors: { message: [I18n.t('activerecord.errors.models.progress_document.attributes.document.document_missing')] }}, :unprocessable_entity) }
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,10 @@ en:
               description_blank: "cannot be blank if joint governance manager type is selected"
             stage:
               inclusion: "is not one of the allowed stage options"
+        progress_document:
+          attributes:
+            document:
+              document_missing: Progress notes must have a document attachment
 
   models:
     criterium:


### PR DESCRIPTION
Currently validations are not being run on nested document attachments. this PR manually checks the params for missing progress document attachments and raises an error if it find any

Testing:
- submit a progress document with notes but no attachment: see error
- add an attachment: should submit and save the progress document