### PR TITLE
feat: Removed governance type from commitment table filters and rest…

### DIFF
--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -76,7 +76,7 @@ class Commitment < ApplicationRecord
     end
   end
 
-  FILTERS = %w[actor country committed_year stage primary_objectives governance_type].freeze
+  FILTERS = %w[actor country committed_year stage primary_objectives].freeze
 
   # Filters moved to CommitmentPresenter to avoid repetition
   def self.filters_to_json
@@ -148,7 +148,6 @@ class Commitment < ApplicationRecord
   def self.parse_filters(filters)
     country_ids = []
     objective_ids = []
-    governance_type_ids = []
     manager_ids = []
     params = {}
     FILTERS.each { |filter| params[filter] = nil }
@@ -169,10 +168,6 @@ class Commitment < ApplicationRecord
         objectives = options
         objective_ids << Objective.where(name: objectives).pluck(:id)
         params['objective'] = objective_ids.flatten.empty? ? "" : "objectives.id IN (#{objective_ids.join(',')})"
-      when 'governance_type'
-        governance_types = options
-        governance_type_ids << GovernanceType.where(name: governance_types).pluck(:id)
-        params['governance_type'] = governance_type_ids.flatten.empty? ? "" : "governance_types.id IN (#{governance_type_ids.join(',')})"
       else
         # Single quoted strings needed for the SQL queries to work properly
         params[name] = options.empty? ? "" : "commitments.#{name} IN (#{options.map { |op| "'#{op}'" }.join(',')})"

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -12,6 +12,7 @@ class Manager < ApplicationRecord
   ]
 
   scope :commitment_form_options, -> { where("default_option IS true AND name != 'None of the above'") }
+  scope :filter_options, -> { where("default_option IS true AND name != 'Sub-national government'") }
   
   has_and_belongs_to_many :commitments
   

--- a/app/presenters/commitment_presenter.rb
+++ b/app/presenters/commitment_presenter.rb
@@ -22,11 +22,9 @@ class CommitmentPresenter
     when 'committed_year'
       Commitment.where.not(committed_year: nil).distinct.pluck(:committed_year)
     when 'actor'
-      Manager.pluck(:name).sort
+      Manager.filter_options.pluck(:name).sort
     when 'primary_objectives'
-      Objective.pluck(:name).sort
-    when 'governance_type'
-      GovernanceType.pluck(:name).sort
+      Objective.commitment_form_options.pluck(:name).sort
     else
       Commitment.pluck(filter.to_sym).uniq.compact.map(&:squish)
     end

--- a/app/presenters/commitment_presenter.rb
+++ b/app/presenters/commitment_presenter.rb
@@ -20,13 +20,15 @@ class CommitmentPresenter
     when 'country'
       Country.pluck(:name).sort
     when 'committed_year'
-      Commitment.where.not(committed_year: nil).distinct.pluck(:committed_year)
+      before_years = Commitment.where('committed_year ILIKE ?', "%before%").distinct.pluck(:committed_year).sort
+      other_years = Commitment.where('committed_year IS NOT NULL AND committed_year NOT ILIKE ?', "%before%").distinct.pluck(:committed_year).sort
+      before_years + other_years
     when 'actor'
       Manager.filter_options.pluck(:name).sort
     when 'primary_objectives'
       Objective.commitment_form_options.pluck(:name).sort
     else
-      Commitment.pluck(filter.to_sym).uniq.compact.map(&:squish)
+      Commitment.pluck(filter.to_sym).uniq.compact.map(&:squish).sort
     end
   end
 end


### PR DESCRIPTION
- Removes the governance type filter from the commitments index table
- Restricts the options in 'Actors' and 'Objectives' filters to those in the forms, minus the ones that are not valid for commitments

Testing:
- go to commitments index
- check options look right, e.g. no duplicated options with slightly different working
- check filters still work