### PR TITLE
Feat/55 fix area based commitments duplication and action agenda tab name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Action Agenda
+# Commitments for Nature
 
 
 ## Ruby version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,7 @@ en:
       hero:
         button: Make a commitment
         subtitle: Capturing Area-Based Commitments
-        title: Capturing Area-Based Commitments
+        title: Commitments for Nature
       map:
         header: Explore Commitments
         placeholder: Search by country


### PR DESCRIPTION
Changes the home page title to say 'Commitments for Nature'

# Testing
- go to home page
- see text in hero now says 'Commitments for Nature'