### PR TITLE
Styled charts and moved additional options text to locales

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -50,15 +50,13 @@ display: none;
   }
 
   .popup__container {
-    max-width: rem-calc(320);
-
     p {
       font-size: medium;
     }
   }
 
   #bar-chart {
-    width: rem-calc(200);
+    width: rem-calc(250);
     height: rem-calc(230);
   }
 
@@ -142,7 +140,7 @@ display: none;
     line-height: 1;
     margin: 0;
     padding: 0 rem-calc(12);
-    min-width: rem-calc(140);
+    min-width: 10pc;
     margin-bottom: rem-calc(8);
 
     &-item {

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -140,7 +140,7 @@ display: none;
     line-height: 1;
     margin: 0;
     padding: 0 rem-calc(12);
-    min-width: 10pc;
+    min-width: 10rem;
     margin-bottom: rem-calc(8);
 
     &-item {

--- a/app/controllers/country_commitments_controller.rb
+++ b/app/controllers/country_commitments_controller.rb
@@ -4,7 +4,7 @@ class CountryCommitmentsController < ApplicationController
   
   def index
     respond_to do |format|
-      format.json { 
+      format.json {
         countries_with_commitments_ids = Commitment.where(state: 'live').joins(:countries).pluck('countries.id').uniq
         countries = Country.where(id: countries_with_commitments_ids).displayable.eager_load(:commitments)
         render json: countries.as_json(except: [:boundary, :created_at, :updated_at], methods: :commitment_count) 

--- a/app/javascript/components/map/MapPopup.vue
+++ b/app/javascript/components/map/MapPopup.vue
@@ -35,7 +35,6 @@ export default {
       id: this.content.id,
       chartData: Object,
       url: '',
-      text: '',
       colors: [
         "#97001F",
         "#6054BA",
@@ -102,7 +101,6 @@ export default {
         .then((response) => {
           this.chartData = response.data.managers;
           this.url = response.data.country_commitments_path;
-          this.text = response.data.text;
         })
         .then(() => this.populateChartData());
     },

--- a/app/javascript/components/map/MapPopup.vue
+++ b/app/javascript/components/map/MapPopup.vue
@@ -8,10 +8,6 @@
       <BarChart :chartData="data" :options="options" :key="randomKey" />
       <MapLegend :data="data.datasets" />
     </div>
-    <div class="map__info-box">
-      <span class="map__info-box-icon"></span>
-        {{ this.text }}
-    </div>
     <button @click="onClick" class="map__button">view commitments</button>
   </div>
 </template>
@@ -66,6 +62,21 @@ export default {
                 min: 0,
                 display: false,
               },
+              scaleLabel: {
+                display: true,
+                fontSize: 25,
+                labelString: 'Number of Commitments',
+              }
+            },
+          ],
+          xAxes: [
+            {
+              scaleFontSize: 100,
+              scaleLabel: {
+                display: true,
+                fontSize: 25,
+                labelString: 'Actor',
+              }
             },
           ],
         },

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -25,7 +25,7 @@ class Country < ApplicationRecord
                 .select("COUNT(*) AS count")
                 .as_json(only: [:name, :percentage, :count])
     
-    { country_name: name, commitment_count: commitment_count_for_country, managers: managers, text: I18n.t('views.home.map.information_text') }
+    { country_name: name, commitment_count: commitment_count_for_country, managers: managers }
   end
 
   def commitment_count

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -1,13 +1,13 @@
 class Manager < ApplicationRecord
   DEFAULT_OPTIONS = [
-    'Local communities', 
-    'Indigenous peoples', 
-    'Non-governmental organisation (NGO)', 
-    'For-profit organisation (business and industry)', 
-    'Sub-national government', 
-    'Joint governance (i.e. decisions are made by many)', 
-    'Individual landowners', 
-    'Collaborative governance (i.e. decisions are made by one group on behalf of many)', 
+    'Local communities',
+    'Indigenous peoples',
+    'Non-governmental organisation',
+    'For-profit organisation',
+    'Sub-national government',
+    'Joint governance',
+    'Individual landowners',
+    'Collaborative governance',
     'Other'
   ]
 

--- a/app/models/services/commitment_props.rb
+++ b/app/models/services/commitment_props.rb
@@ -343,15 +343,6 @@ class Services::CommitmentProps
     }
   end
 
-  # def form_option_text(name, klass)
-  #   underscore_name = name.downcase.gsub(' ', '_').to_sym
-  #   if I18n.t("models.#{ klass }.additional_form_text").keys.include?(underscore_name.to_sym)
-  #     I18n.t("models.#{ klass }.additional_form_text.#{ underscore_name }")
-  #   else
-  #     name
-  #   end
-  # end
-  
   def duration_years_choices
     choices = (5..40).to_a
     choices << "40+"

--- a/app/models/services/commitment_props.rb
+++ b/app/models/services/commitment_props.rb
@@ -1,8 +1,9 @@
 class Services::CommitmentProps
   include Rails.application.routes.url_helpers
 
-  def initialize(commitment)
+  def initialize(commitment, form_option_text_service = Services::FormOptionText.new)
     @commitment = commitment
+    @form_option_text_service = form_option_text_service
   end
 
   def call
@@ -74,7 +75,7 @@ class Services::CommitmentProps
                 choices: Objective.commitment_form_options.pluck(:id, :name).map do |id, name|
                            {
                              value: id,
-                             text: form_option_text(name, 'objective')
+                             text: @form_option_text_service.call(name, 'objective')
                            }
                          end.compact
               },
@@ -89,7 +90,7 @@ class Services::CommitmentProps
                            next unless name != 'None of the above'
                            {
                              value: id,
-                             text: name
+                             text: @form_option_text_service.call(name, 'manager')
                            }
                          end.compact,
                 otherText: I18n.t('form.none')
@@ -108,7 +109,6 @@ class Services::CommitmentProps
             title: 'Location',
             description: I18n.t('form.commitments.page2.description'),
             elements: [
-              # currently not working
               {
                 type: 'tagbox',
                 name: 'country_ids',
@@ -241,7 +241,7 @@ class Services::CommitmentProps
 
                            {
                              value: id,
-                             text: form_option_text(name, 'action')
+                             text: @form_option_text_service.call(name, 'action')
                            }
                          end.compact,
                 otherText: 'Other'
@@ -266,7 +266,7 @@ class Services::CommitmentProps
 
                            {
                              value: id,
-                             text: form_option_text(name, 'threat')
+                             text: @form_option_text_service.call(name, 'threat')
                            }
                          end.compact
               },
@@ -343,14 +343,14 @@ class Services::CommitmentProps
     }
   end
 
-  def form_option_text(name, klass)
-    underscore_name = name.downcase.gsub(' ', '_').to_sym
-    if I18n.t("models.#{ klass }.additional_form_text").keys.include?(underscore_name.to_sym)
-      I18n.t("models.#{ klass }.additional_form_text.#{ underscore_name }")
-    else
-      name
-    end
-  end
+  # def form_option_text(name, klass)
+  #   underscore_name = name.downcase.gsub(' ', '_').to_sym
+  #   if I18n.t("models.#{ klass }.additional_form_text").keys.include?(underscore_name.to_sym)
+  #     I18n.t("models.#{ klass }.additional_form_text.#{ underscore_name }")
+  #   else
+  #     name
+  #   end
+  # end
   
   def duration_years_choices
     choices = (5..40).to_a

--- a/app/models/services/criterium_props.rb
+++ b/app/models/services/criterium_props.rb
@@ -1,6 +1,7 @@
 class Services::CriteriumProps
-  def initialize(criterium)
+  def initialize(criterium, form_option_text_service = Services::FormOptionText.new)
     @criterium = criterium
+    @form_option_text_service = form_option_text_service
   end
 
   def call
@@ -69,7 +70,7 @@ class Services::CriteriumProps
                           if name != 'Other'
                             {
                               value: id,
-                              text: name
+                              text: @form_option_text_service.call(name, 'manager')
                             }
                           else
                             nil
@@ -120,4 +121,13 @@ class Services::CriteriumProps
       }
     }
   end
+
+  # def form_option_text(name, klass)
+  #   underscore_name = name.downcase.gsub(' ', '_').to_sym
+  #   if I18n.t("models.#{ klass }.additional_form_text").keys.include?(underscore_name.to_sym)
+  #     I18n.t("models.#{ klass }.additional_form_text.#{ underscore_name }")
+  #   else
+  #     name
+  #   end
+  # end
 end

--- a/app/models/services/criterium_props.rb
+++ b/app/models/services/criterium_props.rb
@@ -121,13 +121,4 @@ class Services::CriteriumProps
       }
     }
   end
-
-  # def form_option_text(name, klass)
-  #   underscore_name = name.downcase.gsub(' ', '_').to_sym
-  #   if I18n.t("models.#{ klass }.additional_form_text").keys.include?(underscore_name.to_sym)
-  #     I18n.t("models.#{ klass }.additional_form_text.#{ underscore_name }")
-  #   else
-  #     name
-  #   end
-  # end
 end

--- a/app/models/services/form_option_text.rb
+++ b/app/models/services/form_option_text.rb
@@ -1,0 +1,10 @@
+class Services::FormOptionText
+  def call(name, klass)
+    underscore_name = name.downcase.gsub(' ', '_').to_sym
+    if I18n.t("models.#{ klass }.additional_form_text").keys.include?(underscore_name.to_sym)
+      I18n.t("models.#{ klass }.additional_form_text.#{ underscore_name }")
+    else
+      name
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,12 @@ en:
         natural_system_modifications: Natural system modifications (e.g. dams, land reclamation, fire management)
         geological_events: Geological events (e.g. volcanoes, earthquakes, landslides)
         climate_change_or_severe_weather: Climate change or severe weather (e.g. flooding, droughts, habitat changes, temperature changes)
+    manager:
+      additional_form_text:
+        for-profit_organisation: For-profit organisation (business and industry)
+        collaborative_governance: Collaborative governance (i.e. decisions are made by one group on behalf of many)
+        joint_governance: Joint governance (i.e. decisions are made by many)
+        non-governmental_organisation: Non-governmental organisation (NGO)
 
   views:
     titles:
@@ -119,4 +125,3 @@ en:
         header: Explore Commitments
         placeholder: Search by country
         button: View Commitments
-        information_text: The figure above presents the relative proportion of commitments being made by actor in this country


### PR DESCRIPTION
"The bar charts are not right – there is no label on the axis (y-axis is the number of commitments x-axis is the actor).  The chart could be made wider. The figure is now incorrectly labelled – you can remove that text."

- labels the axes
- made chart wider
- removed label text
- moved additional info in manager form options to a yml instead of in the class name

TO DO: still a lot of styling changes to make to the map, so apart from what has been changed here, please ignore other map styling issues
 
Testing:
- Click charts on the home page and check above changes are applied
- go to criteria form and check it displays the options with the additional text