### PR TITLE
Fix/table pagination after filtering

### DIFF
--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -19,6 +19,7 @@ class CommitmentsController < ApplicationController
     @paginatedCommitments = Commitment.paginate_commitments(DEFAULT_PARAMS.to_json).to_json
     @filters = Commitment.filters_to_json
     @table_attributes = Commitment::TABLE_ATTRIBUTES.to_json
+    @preset_filters = DEFAULT_PARAMS[:filters]
   end
 
   def show

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -12,14 +12,16 @@ class CommitmentsController < ApplicationController
   before_action :clean_progress_document_attachment_params, only: [:update, :create]
 
   def index
+    # make a copy of default params and modify those to prevent filters persisting over calls
+    filter_params = DEFAULT_PARAMS.dup
     if params[:country_filters].present?
-      DEFAULT_PARAMS[:filters] = [] # Previous search filters are persisted across calls unless we clear them
-      DEFAULT_PARAMS[:filters] << params[:country_filters]
+      filter_params[:filters] = []
+      filter_params[:filters] << params[:country_filters]
     end
-    @paginatedCommitments = Commitment.paginate_commitments(DEFAULT_PARAMS.to_json).to_json
+    @paginatedCommitments = Commitment.paginate_commitments(filter_params.to_json).to_json
     @filters = Commitment.filters_to_json
     @table_attributes = Commitment::TABLE_ATTRIBUTES.to_json
-    @preset_filters = DEFAULT_PARAMS[:filters]
+    @preset_filters = filter_params[:filters]
   end
 
   def show

--- a/app/javascript/components/filters/DataFilter.vue
+++ b/app/javascript/components/filters/DataFilter.vue
@@ -52,9 +52,8 @@
         type: String
       },
       presetFilterOptions: {
-        required: true,
         type: Array,
-        default: []
+        default: () => []
       }
     },
 
@@ -146,10 +145,7 @@
       },
 
       isSelected(option) {
-        const selected = this.presetFilterOptions.filter(obj => {
-            return obj === option
-          })
-        return selected.length > 0
+        return this.presetFilterOptions.includes(option)
       }
     }
   }

--- a/app/javascript/components/filters/DataFilter.vue
+++ b/app/javascript/components/filters/DataFilter.vue
@@ -15,7 +15,7 @@
             v-if="option != null"
             :key="`${title}-${index}`"
             :option="option"
-            :selected="false">
+            :selected="isSelected(option)">
           </data-filter-option>
         </template>
       </ul>
@@ -50,6 +50,11 @@
       },
       type: {
         type: String
+      },
+      presetFilterOptions: {
+        required: true,
+        type: Array,
+        default: []
       }
     },
 
@@ -72,7 +77,7 @@
 
         this.children.forEach(child => {
           if(child.isSelected){ 
-            selectedArray.push(child.option) 
+            selectedArray.push(child.option)
           }
         })
 
@@ -138,6 +143,13 @@
         this.$eventHub.$emit('getNewItems')
 
         this.$eventHub.$emit('filtersChanged')
+      },
+
+      isSelected(option) {
+        const selected = this.presetFilterOptions.filter(obj => {
+            return obj === option
+          })
+        return selected.length > 0
       }
     }
   }

--- a/app/javascript/components/filters/DataFilterOption.vue
+++ b/app/javascript/components/filters/DataFilterOption.vue
@@ -11,10 +11,11 @@
 
     props: {
       option: {
+        type: String,
         required: true
       },
       selected: {
-        required: true,
+        type: Boolean,
         default: false
       }
     },

--- a/app/javascript/components/filters/DataFilterOption.vue
+++ b/app/javascript/components/filters/DataFilterOption.vue
@@ -12,12 +12,16 @@
     props: {
       option: {
         required: true
+      },
+      selected: {
+        required: true,
+        default: false
       }
     },
 
     data () {
       return {
-        isSelected: false
+        isSelected: this.selected
       }
     },
 
@@ -26,11 +30,5 @@
         return this.option.toString().replace(' |(|)|_', '-').toLowerCase()
       }
     },
-
-    methods: {
-      selectOption (option) {
-        this.isSelected = true
-      }
-    }
   }
 </script>

--- a/app/javascript/components/filters/Filters.vue
+++ b/app/javascript/components/filters/Filters.vue
@@ -21,8 +21,8 @@
 
     props: {
       filters: {
-        required: true,
-        type: Array
+        type: Array,
+        default: () => []
       },
       presetFilters: {
         type: Array,
@@ -72,8 +72,8 @@
       },
 
       presetOptionsForFilter(filterName) {
-        const preselected = this.presetFilters.filter(presetFilter => presetFilter.name === filterName)
-        return preselected.length > 0 ? preselected[0]['options'] : []
+        const preselected = this.presetFilters.find(presetFilter => presetFilter.name === filterName)
+        return preselected ? preselected?.options : []
       }
     }
   }

--- a/app/javascript/components/filters/Filters.vue
+++ b/app/javascript/components/filters/Filters.vue
@@ -5,7 +5,8 @@
       :name="filter.name"
       :title="filter.title" 
       :options="filter.options"
-      :type="filter.type">
+      :type="filter.type"
+      :presetFilterOptions="presetOptionsForFilterType(filter.name)">
     </data-filter>
   </div>
 </template>
@@ -22,6 +23,11 @@
       filters: {
         required: true,
         type: Array
+      },
+      presetFilters: {
+        required: true,
+        type: Array,
+        default: []
       }
     },
 
@@ -49,11 +55,14 @@
 
         // create an empty array for each filter
         this.filters.forEach(filter => {
+
           if (filter.name !== undefined && filter.options.length > 0) {
+            const preselected = this.presetOptionsForFilterType(filter.name)
+
             let obj = {}
 
             obj.name = filter.name
-            obj.options = []
+            obj.options = preselected
             obj.type = filter.type
 
             array.push(obj)
@@ -61,6 +70,13 @@
         })
 
         this.$store.dispatch('table/setFilterOptions', array)
+      },
+
+      presetOptionsForFilterType(filterName) {
+        const preselected = this.presetFilters.filter(obj => {
+            return obj.name === filterName
+          })
+        return preselected.length > 0 ? preselected[0]['options'] : []
       }
     }
   }

--- a/app/javascript/components/filters/Filters.vue
+++ b/app/javascript/components/filters/Filters.vue
@@ -73,7 +73,7 @@
 
       presetOptionsForFilter(filterName) {
         const preselected = this.presetFilters.find(presetFilter => presetFilter.name === filterName)
-        return preselected ? preselected?.options : []
+        return preselected?.options || []
       }
     }
   }

--- a/app/javascript/components/filters/Filters.vue
+++ b/app/javascript/components/filters/Filters.vue
@@ -6,8 +6,8 @@
       :title="filter.title" 
       :options="filter.options"
       :type="filter.type"
-      :presetFilterOptions="presetOptionsForFilterType(filter.name)">
-    </data-filter>
+      :presetFilterOptions="presetOptionsForFilter(filter.name)"
+    />
   </div>
 </template>
 
@@ -25,9 +25,8 @@
         type: Array
       },
       presetFilters: {
-        required: true,
         type: Array,
-        default: []
+        default: () => []
       }
     },
 
@@ -57,7 +56,7 @@
         this.filters.forEach(filter => {
 
           if (filter.name !== undefined && filter.options.length > 0) {
-            const preselected = this.presetOptionsForFilterType(filter.name)
+            const preselected = this.presetOptionsForFilter(filter.name)
 
             let obj = {}
 
@@ -72,10 +71,8 @@
         this.$store.dispatch('table/setFilterOptions', array)
       },
 
-      presetOptionsForFilterType(filterName) {
-        const preselected = this.presetFilters.filter(obj => {
-            return obj.name === filterName
-          })
+      presetOptionsForFilter(filterName) {
+        const preselected = this.presetFilters.filter(presetFilter => presetFilter.name === filterName)
         return preselected.length > 0 ? preselected[0]['options'] : []
       }
     }

--- a/app/javascript/components/table/FilteredTable.vue
+++ b/app/javascript/components/table/FilteredTable.vue
@@ -57,9 +57,8 @@
       filters: { type: Array },
       paginatedRows: { type: Object },
       presetFilters: { 
-        required: true,
         type: Array,
-        default: []
+        default: () => []
       },
     },
 

--- a/app/javascript/components/table/FilteredTable.vue
+++ b/app/javascript/components/table/FilteredTable.vue
@@ -4,6 +4,7 @@
       class="filters"
       :filters="filters"
       :total-items="totalItems"
+      :presetFilters="presetFilters"
     />
 
     <table class="table-head table-head--basic">
@@ -54,7 +55,8 @@
         type: String
       },
       filters: { type: Array },
-      paginatedRows: { type: Object }
+      paginatedRows: { type: Object },
+      presetFilters: { type: Array },
     },
 
     data () {

--- a/app/javascript/components/table/FilteredTable.vue
+++ b/app/javascript/components/table/FilteredTable.vue
@@ -56,7 +56,11 @@
       },
       filters: { type: Array },
       paginatedRows: { type: Object },
-      presetFilters: { type: Array },
+      presetFilters: { 
+        required: true,
+        type: Array,
+        default: []
+      },
     },
 
     data () {

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -201,10 +201,7 @@ class Commitment < ApplicationRecord
 
   def self.pages(item_count)
     return 0 if item_count == 0
-
-    full_page_count = item_count / @items_per_page
-    full_page_count += 1 unless item_count % @items_per_page == 0
-    full_page_count
+    (item_count / @items_per_page.to_d).ceil
   end
 
   private

--- a/app/views/commitments/index.html.erb
+++ b/app/views/commitments/index.html.erb
@@ -10,5 +10,6 @@
     endpoint="/commitments/list"
     :filters="<%= @filters %>" 
     :paginated-rows="<%= @paginatedCommitments %>"
+    :preset-filters="<%= @preset_filters.to_json %>"
   ></filtered-table>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,10 @@ Manager.create!(Manager::DEFAULT_OPTIONS.map {|manager_name| { name: manager_nam
 cbd_objective_names = [ 'Conservation of biological diversity', 'Sustainable use', 'Fair and equitable sharing of benefits from the utilization of genetic resources', 'None of the above' ]
 CbdObjective.create!(cbd_objective_names.map {|name| { name: name }})
 
+Action.create!(Action::DEFAULT_OPTIONS.map {|action_name| { name: action_name, default_option: true }})
+Threat.create!(Threat::DEFAULT_OPTIONS.map {|threat_name| { name: threat_name, default_option: true }})
+Objective.create!(Objective::DEFAULT_OPTIONS.map {|objective_name| { name: objective_name, default_option: true }})
+
 criteria = [
   { boundary: true, five_year_commitment: true, progress_report: true, managers: [Manager.first], cbd_objectives: [CbdObjective.first], user: User.first },
   { boundary: false, five_year_commitment: true, progress_report: true, managers: [Manager.first], cbd_objectives: [CbdObjective.first], user: User.first },
@@ -21,10 +25,3 @@ criteria = [
   { boundary: false, five_year_commitment: false, progress_report: false, managers: [Manager.last], cbd_objectives: [CbdObjective.last], user: User.first }
 ]
 Criterium.create!(criteria)
-
-# Commitments and associated records
-Country.import
-
-Action.create!(Action::DEFAULT_OPTIONS.map {|action_name| { name: action_name, default_option: true }})
-Threat.create!(Threat::DEFAULT_OPTIONS.map {|threat_name| { name: threat_name, default_option: true }})
-Objective.create!(Objective::DEFAULT_OPTIONS.map {|objective_name| { name: objective_name, default_option: true }})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,29 +28,3 @@ Country.import
 Action.create!(Action::DEFAULT_OPTIONS.map {|action_name| { name: action_name, default_option: true }})
 Threat.create!(Threat::DEFAULT_OPTIONS.map {|threat_name| { name: threat_name, default_option: true }})
 Objective.create!(Objective::DEFAULT_OPTIONS.map {|objective_name| { name: objective_name, default_option: true }})
-
-commitments = [
-  {
-    geographic_boundary: true, latitude: 0.002, longitude: 0.9, current_area_ha: 12, proposed_area_ha: 15, 
-    committed_year: 2021, implementation_year: 2022, name: 'A commitment', 
-    governance_authority: 'A governance authority name', description: 'A description',
-    duration_years: 5, user: User.first, criterium: Criterium.first,
-    stage: 'Implemented fully', responsible_group: 'The responsible group', state: 'live',
-    threats: Threat.all, actions: Action.all, managers: Manager.all, countries: Country.where(id: 1..5), objectives: Objective.all
-  },
-  {
-    geographic_boundary: true, latitude: 0.002, longitude: 0.9, current_area_ha: 12, proposed_area_ha: 15, 
-    committed_year: 2021, implementation_year: 2022, name: 'A commitment', 
-    governance_authority: 'A governance authority name', description: 'A description',
-    duration_years: 5, user: User.second, criterium: Criterium.first,
-    stage: 'Implemented fully', responsible_group: 'The responsible group', state: 'live',
-    threats: Threat.all, actions: Action.all, managers: Manager.all, countries: Country.where(id: 1..5), objectives: Objective.all
-  }
-]
-Commitment.create!(commitments)
-
-links = [
-  { url: 'something.com', commitment: Commitment.first },
-  { url: 'something.org', commitment: Commitment.first }
-]
-Link.create!(links)


### PR DESCRIPTION
Should fix:
1. the issue with filtered table only returning 10 results and no pagination
2. second issue discovered after this where the filtering on country via the url was not being transmitted when the next page button was clicked

part 1. required changing the pagination logic which was returning either the total number of commitments in db when no filter, or the number of commitments on the page with a filter. instead, we get a count of all the commitments returned by the filter before pagination

part 2. Pass a prop to the table with pre-selected filters, which is then used to pre-select the relevant options in the filters. probably needs a refactor by someone who knows what they're doing

Testing:
check pagination works with the table after filters are applied
frrom the map, view commitments for a country and should be pre-filtered, and pagination should work
 