### PR TITLE
Feat/64 add share permissions to form

### DIFF
--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -156,6 +156,7 @@ class CommitmentsController < ApplicationController
       :longitude,
       :name,
       :responsible_group,
+      :shareable,
       :stage,
       :state,
       :manager_id,

--- a/app/javascript/components/forms/SurveyForm.vue
+++ b/app/javascript/components/forms/SurveyForm.vue
@@ -236,7 +236,6 @@ export default {
         this.addDestroyKeys(data);
         this.send(data);
       }
-      Turbolinks.visit("/dashboard");
     },
 
     nextPage() {
@@ -437,7 +436,7 @@ export default {
         // set shareable to boolean based on presence/absence of checkbox value array
         data = {
           ...data,
-          shareable: data.shareable ? true : false
+          shareable: !!data.shareable
         };
       }
       this.options = {

--- a/app/javascript/components/forms/SurveyForm.vue
+++ b/app/javascript/components/forms/SurveyForm.vue
@@ -433,6 +433,12 @@ export default {
     send(data) {
       if (this.dataModel === "Criterium") {
         this.assignNoneValues(data);
+      } else {
+        // set shareable to boolean based on presence/absence of checkbox value array
+        data = {
+          ...data,
+          shareable: data.shareable ? true : false
+        };
       }
       this.options = {
         method: this.formData.config.method,

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -42,6 +42,8 @@ class Commitment < ApplicationRecord
 
   validates_presence_of :description, :latitude, :longitude, :committed_year, :responsible_group, :implementation_year,
                         :duration_years, :objectives, :manager, :countries, :actions, :threats, if: :user_created_and_live?
+
+  validate :name_is_10_words_or_less, if: :user_created_and_live?
   
   TABLE_ATTRIBUTES = [
     {
@@ -212,5 +214,9 @@ class Commitment < ApplicationRecord
 
   def user_created_and_live?
     live? && user_created?
+  end
+
+  def name_is_10_words_or_less
+    errors.add(:name, :too_long) if name && name.split(' ').length > 10
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -24,7 +24,7 @@ class Country < ApplicationRecord
                 .select('managers.name AS name')
                 .select("COUNT(*) AS count")
                 .as_json(only: [:name, :percentage, :count])
-    
+
     { country_name: name, commitment_count: commitment_count_for_country, managers: managers }
   end
 

--- a/app/models/services/commitment_props.rb
+++ b/app/models/services/commitment_props.rb
@@ -57,7 +57,14 @@ class Services::CommitmentProps
                 description: I18n.t('form.commitments.page1.q1.description'),
                 isRequired: true,
                 popupdescription: I18n.t('form.commitments.page1.q1.popupdescription_html'),
-                defaultValue: @commitment.name || ''
+                defaultValue: @commitment.name || '',
+                validators: [
+                  { 
+                    type: 'regex',
+                    text: I18n.t('form.commitments.page1.q1.validation'),  
+                    regex: '^\s*(\S+\s+|\S+$){1,10}$'
+                  }
+                ]
               },
               {
                 type: 'comment',
@@ -125,7 +132,14 @@ class Services::CommitmentProps
                     titleLocation: 'left',
                     placeHolder: '00.00000000',
                     hideNumber: true,
-                    defaultValue: @commitment.latitude || ''
+                    defaultValue: @commitment.latitude || '',
+                    validators: [
+                      { 
+                        type: 'regex',
+                        text: I18n.t('form.commitments.page2.q3.validation'),  
+                        regex: '^([+-])?(?:90(?:\\.0{1,6})?|((?:|[1-8])[0-9])(?:\\.[0-9]{1,6})?)$'
+                      }
+                    ]
                   },
                   {
                     type: 'text',
@@ -134,7 +148,14 @@ class Services::CommitmentProps
                     titleLocation: 'left',
                     placeHolder: '00.00000000',
                     hideNumber: true,
-                    defaultValue: @commitment.longitude || ''
+                    defaultValue: @commitment.longitude || '',
+                    validators: [
+                      { 
+                        type: 'regex',
+                        text: I18n.t('form.commitments.page2.q4.validation'),  
+                        regex: '^([+-])?(?:180(?:\\.0{1,6})?|((?:|[1-9]|1[0-7])[0-9])(?:\\.[0-9]{1,6})?)$'
+                      }
+                    ]
                   },
                   {
                     type: 'file',
@@ -271,7 +292,6 @@ class Services::CommitmentProps
                     type: 'text',
                     title: 'hidden field',
                     name: 'id',
-                    # a bit of a hacky way to make it work
                     visibleIf: 'false'
                   },
                   {
@@ -303,7 +323,6 @@ class Services::CommitmentProps
                     type: 'text',
                     title: 'hidden field',
                     name: 'id',
-                    # a bit of a hacky way to make it work
                     visibleIf: 'false'
                   },
                   {
@@ -326,6 +345,18 @@ class Services::CommitmentProps
                 confirmDelete: true,
                 confirmDeleteText: I18n.t('form.commitments.page5.q1.delete'),
                 panelAddText: I18n.t('form.commitments.page5.q1.add')
+              },
+              {
+                type: 'checkbox',
+                name: 'shareable',
+                titleLocation: 'hidden',
+                defaultValue: !!@commitment.shareable,
+                choices: [
+                  {
+                    value: true,
+                    text: I18n.t('form.commitments.page5.q2.option_text')
+                  }
+                ]
               }
             ]
           }

--- a/app/models/services/commitment_props.rb
+++ b/app/models/services/commitment_props.rb
@@ -62,7 +62,7 @@ class Services::CommitmentProps
                   { 
                     type: 'regex',
                     text: I18n.t('form.commitments.page1.q1.validation'),  
-                    regex: '^\s*(\S+\s+|\S+$){1,10}$'
+                    regex: regex_10_word_maximum
                   }
                 ]
               },
@@ -137,7 +137,7 @@ class Services::CommitmentProps
                       { 
                         type: 'regex',
                         text: I18n.t('form.commitments.page2.q3.validation'),  
-                        regex: '^([+-])?(?:90(?:\\.0{1,6})?|((?:|[1-8])[0-9])(?:\\.[0-9]{1,6})?)$'
+                        regex: regex_latitude
                       }
                     ]
                   },
@@ -153,7 +153,7 @@ class Services::CommitmentProps
                       { 
                         type: 'regex',
                         text: I18n.t('form.commitments.page2.q4.validation'),  
-                        regex: '^([+-])?(?:180(?:\\.0{1,6})?|((?:|[1-9]|1[0-7])[0-9])(?:\\.[0-9]{1,6})?)$'
+                        regex: regex_longitude
                       }
                     ]
                   },
@@ -201,6 +201,7 @@ class Services::CommitmentProps
                 type: 'comment',
                 name: 'area_owner_and_role',
                 title: I18n.t('form.commitments.page2.q8.title'),
+                description: I18n.t('form.commitments.page2.q8.description'),
                 defaultValue: @commitment.area_owner_and_role || ''
               }
             ]
@@ -376,5 +377,20 @@ class Services::CommitmentProps
     choices << 'after 2030'
     choices.unshift('before 2010')
     choices
+  end
+
+  def regex_10_word_maximum
+    # https://stackoverflow.com/questions/1526881/use-a-regularexpressionvalidator-to-limit-a-word-count
+    '^\s*(\S+\s+|\S+$){1,10}$'
+  end
+
+  def regex_latitude
+    # https://stackoverflow.com/questions/3518504/regular-expression-for-matching-latitude-longitude-coordinates
+    '^([+-])?(?:90(?:\\.0{1,6})?|((?:|[1-8])[0-9])(?:\\.[0-9]{1,6})?)$'
+  end
+
+  def regex_longitude
+    # https://stackoverflow.com/questions/3518504/regular-expression-for-matching-latitude-longitude-coordinates
+    '^([+-])?(?:180(?:\\.0{1,6})?|((?:|[1-9]|1[0-7])[0-9])(?:\\.[0-9]{1,6})?)$'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
             stage:
               inclusion: "is not one of the allowed stage options"
             name:
-              too_long: Must be 10 words or less
+              too_long: Must be 10 words or fewer
         progress_document:
           attributes:
             document:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,8 @@ en:
           attributes:
             stage:
               inclusion: "is not one of the allowed stage options"
+            name:
+              too_long: Must be 10 words or less
         progress_document:
           attributes:
             document:

--- a/config/locales/form/en.yml
+++ b/config/locales/form/en.yml
@@ -76,7 +76,7 @@ en:
           popupdescription_html:
             Please name your commitment in up to 10 words. This is the name that will appear on the platform. 
             Examples include 'Establishment of Cambridge community conserved area', 'Expansion of Cambridge private reserve', 
-            or 'Improvement of management for sustainable use at Cambridge Farm''
+            or 'Improvement of management for sustainable use at Cambridge Farm'
           validation: Commitment name can be a maximum of 10 words
         q2:
           title: Please provide a description of your commitment
@@ -109,10 +109,10 @@ en:
             If unknown, please use this website: <a href="https://www.latlong.net/" target="_blank">https://www.latlong.net/</a>.'
         q3:
           title: Latitude
-          validation: 'Latitude must be a number between -90 and 90, with up to 6 decimal places'
+          validation: Latitude must be a number between -90 and 90, with up to 6 decimal places
         q4:
           title: Longitude
-          validation: 'Longitude must be a number between -180 and 180, with up to 6 decimal places'
+          validation: Longitude must be a number between -180 and 180, with up to 6 decimal places
         q5:
           title: If you have spatial data you would like to share, please upload it here.
           description: (Optional field)
@@ -128,6 +128,7 @@ en:
           title: Hectares
         q8:
           title: If this area of land or water is owned (legally or customarily) by a group other than the commitment-maker, please indicate the name of the group and their role in the commitment
+          description: (Optional field)
       page3:
         name: '3. Duration'
         q1:
@@ -192,7 +193,7 @@ en:
           option_text: 
             Permission is given to UNEP-WCMC to allow reposting or redistribution by third party platforms 
             (e.g. the Convention on Biological Diversity's Sharm El Sheikh to Kunming Action Agenda Platform,
-            the IUNC Contributions Platform, the CitiesWithNature Action Platform)
+            the IUCN Contributions Platform, and the CitiesWithNature Action Platform)
       modal:
         question: Are you sure you want to exit this page?
         p1: If you still want to exit this page, selecting ‘Exit & Save’ will save any information you have entered so far*. Saved commitments will be accessible through your ‘My Dashboard’ page.

--- a/config/locales/form/en.yml
+++ b/config/locales/form/en.yml
@@ -76,7 +76,8 @@ en:
           popupdescription_html:
             Please name your commitment in up to 10 words. This is the name that will appear on the platform. 
             Examples include 'Establishment of Cambridge community conserved area', 'Expansion of Cambridge private reserve', 
-            or 'Improvement of management for sustainable use at Cambridge Farm'' 
+            or 'Improvement of management for sustainable use at Cambridge Farm''
+          validation: Commitment name can be a maximum of 10 words
         q2:
           title: Please provide a description of your commitment
           popupdescription_html: 
@@ -108,8 +109,10 @@ en:
             If unknown, please use this website: <a href="https://www.latlong.net/" target="_blank">https://www.latlong.net/</a>.'
         q3:
           title: Latitude
+          validation: 'Latitude must be a number between -90 and 90, with up to 6 decimal places'
         q4:
           title: Longitude
+          validation: 'Longitude must be a number between -180 and 180, with up to 6 decimal places'
         q5:
           title: If you have spatial data you would like to share, please upload it here.
           description: (Optional field)
@@ -185,6 +188,11 @@ en:
             In addition, you may also upload any other relevant documents that you would like others to be able to see. These must also be in PDF or Word format. 
             <br><br>
             By loading your updates, you agree that they will be visible to other users of the site. The information you provide will serve to inspire and enable others to learn from different approaches being applied across the world. Showcasing commitments may also inspire investors or donors to support specific initiatives.
+        q2:
+          option_text: 
+            Permission is given to UNEP-WCMC to allow reposting or redistribution by third party platforms 
+            (e.g. the Convention on Biological Diversity's Sharm El Sheikh to Kunming Action Agenda Platform,
+            the IUNC Contributions Platform, the CitiesWithNature Action Platform)
       modal:
         question: Are you sure you want to exit this page?
         p1: If you still want to exit this page, selecting ‘Exit & Save’ will save any information you have entered so far*. Saved commitments will be accessible through your ‘My Dashboard’ page.

--- a/db/migrate/20220413083800_add_shareable_to_commitments.rb
+++ b/db/migrate/20220413083800_add_shareable_to_commitments.rb
@@ -1,0 +1,5 @@
+class AddShareableToCommitments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :commitments, :shareable, :boolean, default: 0, null: true
+  end
+end

--- a/db/migrate/20220413084040_add_cdb_import_to_commitments.rb
+++ b/db/migrate/20220413084040_add_cdb_import_to_commitments.rb
@@ -1,0 +1,5 @@
+class AddCdbImportToCommitments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :commitments, :cbd_import, :boolean, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_11_085523) do
+ActiveRecord::Schema.define(version: 2022_04_13_084040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,8 @@ ActiveRecord::Schema.define(version: 2022_04_11_085523) do
     t.boolean "user_created", default: false, null: false
     t.text "area_owner_and_role"
     t.bigint "manager_id"
+    t.boolean "shareable", default: false
+    t.boolean "cbd_import", default: false, null: false
     t.index ["committed_year"], name: "index_commitments_on_committed_year"
     t.index ["country_id"], name: "index_commitments_on_country_id"
     t.index ["duration_years"], name: "index_commitments_on_duration_years"

--- a/lib/tasks/import_commitments.rake
+++ b/lib/tasks/import_commitments.rake
@@ -34,7 +34,8 @@ namespace :import do
                                  description: cbd_action["description"]["en"],
                                  country_ids: [country.id],
                                  committed_year: cbd_com["meta"]["createdOn"].to_date.year,
-                                 related_biodiversity_targets: aichi_targets
+                                 related_biodiversity_targets: aichi_targets,
+                                 cbd_import: true
                                 )
         our_com.links.build(url: "https://www.cbd.int/action-agenda/contributions/action?action-id=#{cbd_id}")
         our_com.save!


### PR DESCRIPTION
- Adds 10 word limit to Commitment name
- Adds validation to lat and long
- Adds a checkbox giving permission to share the precious data

testing:
- enter more then 10 words to the commitment name and move tabs - see error
- check lat and long only allow valid coordinates
- check the permissions checkbox works
- after publishing a commitment, check you can't save with > 10 words in the name
- check importer runs correctly by resetting db and running the import task (should have 101 commitments in db) 