### PR TITLE
Feat/use operational areas instead of contact country for cbd imports

### DIFF
--- a/app/models/services/cbd_commitment_hash.rb
+++ b/app/models/services/cbd_commitment_hash.rb
@@ -32,8 +32,9 @@ class Services::CbdCommitmentHash
 
     # CDB returns some records with iso codes and some with a longer id, but the longer
     # codes refer to regions rather than countries so we'll exclude them.
-    iso_codes = country_codes.filter {|code| code.length == 2 }.map(&:upcase)
-    countries = Country.where(iso: iso_codes)
+    iso_codes = country_codes.filter {|code| code.length == 2 }
+    upcased_iso_codes = iso_codes.map(&:upcase)
+    countries = Country.where(iso: upcased_iso_codes)
     ids = countries.pluck(:id)
     ids.present? ? ids : [global_country_id]
   end

--- a/app/models/services/cbd_commitment_hash.rb
+++ b/app/models/services/cbd_commitment_hash.rb
@@ -28,12 +28,12 @@ class Services::CbdCommitmentHash
 
     return [global_country_id] if operational_areas.nil?
 
-    country_codes = operational_areas.map { |operational_area| operational_area['identifier'] }
-
     # CDB returns some records with iso codes and some with a longer id, but the longer
     # codes refer to regions rather than countries so we'll exclude them.
-    iso_codes = country_codes.filter {|code| code.length == 2 }
-    upcased_iso_codes = iso_codes.map(&:upcase)
+    upcased_iso_codes = operational_areas.map do |operational_area|
+      operational_area['identifier'].length == 2 ? operational_area['identifier'].upcase : nil
+    end.compact
+
     countries = Country.where(iso: upcased_iso_codes)
     ids = countries.pluck(:id)
     ids.present? ? ids : [global_country_id]

--- a/app/models/services/cbd_commitment_hash.rb
+++ b/app/models/services/cbd_commitment_hash.rb
@@ -25,17 +25,17 @@ class Services::CbdCommitmentHash
 
   def country_ids
     operational_areas = @cbd_hash.dig('actionDetails', 'operationalAreas')
+
+    return [global_country_id] if operational_areas.nil?
+
     country_codes = operational_areas.map { |operational_area| operational_area['identifier'] }
-    
+
     # CDB returns some records with iso codes and some with a longer id, but the longer
     # codes refer to regions rather than countries so we'll exclude them.
     iso_codes = country_codes.filter {|code| code.length == 2 }.map(&:upcase)
     countries = Country.where(iso: iso_codes)
     ids = countries.pluck(:id)
     ids.present? ? ids : [global_country_id]
-  rescue
-    # Will error if operationalAreas is nil.
-    [global_country_id]
   end
 
   def global_country_id

--- a/app/models/services/cbd_commitment_hash.rb
+++ b/app/models/services/cbd_commitment_hash.rb
@@ -11,7 +11,7 @@ class Services::CbdCommitmentHash
       cbd_id: @cbd_hash['_id'],
       name: cbd_action.dig('name', 'en'),
       description: cbd_action.dig('description', 'en'),
-      country_ids: [country_id],
+      country_ids: country_ids,
       committed_year: @cbd_hash.dig('meta', 'createdOn').to_date.year,
       commitment_source: 'cbd',
       cfn_approved: @commitment.cfn_approved,
@@ -23,14 +23,23 @@ class Services::CbdCommitmentHash
     }
   end
 
-  def country_id
-    # @TODO: Change this if CBD changes gives us different information.
-    country_object = @cbd_hash['contacts'][0]['country']
+  def country_ids
+    operational_areas = @cbd_hash.dig('actionDetails', 'operationalAreas')
+    country_codes = operational_areas.map { |operational_area| operational_area['identifier'] }
+    
+    # CDB returns some records with iso codes and some with a longer id, but the longer
+    # codes refer to regions rather than countries so we'll exclude them.
+    iso_codes = country_codes.filter {|code| code.length == 2 }.map(&:upcase)
+    countries = Country.where(iso: iso_codes)
+    ids = countries.pluck(:id)
+    ids.present? ? ids : [global_country_id]
+  rescue
+    # Will error if operationalAreas is nil.
+    [global_country_id]
+  end
 
-    # If no country is found, assign to the 'Global' country record.
-    country_code = country_object.present? ? country_object['identifier'].upcase : '--'
-    country = Country.find_by(iso: country_code)
-    country.id
+  def global_country_id
+    Country.find_by(iso: '--').id
   end
 
   def link_attributes

--- a/app/models/services/cbd_importer.rb
+++ b/app/models/services/cbd_importer.rb
@@ -1,0 +1,29 @@
+class Services::CbdImporter
+
+  def call
+    first_item_position = 0
+    loop do
+      response = HTTParty.get(query(first_item_position))
+
+      # We are requesting 10 items per page, so increment the first_item_position by 10.
+      first_item_position += 10
+      raw_json = JSON.parse(response.body)
+      
+      break if raw_json.empty?
+
+      raw_json.each do |cbd_com|
+        next if cbd_com.nil?
+
+        commitment = Commitment.find_or_initialize_by(cbd_id: cbd_com["_id"])
+        commitment_params = Services::CbdCommitmentHash.new(cbd_com, commitment).call
+        commitment.assign_attributes(commitment_params)
+        commitment.save!
+      end
+    end
+  end
+
+  def query(first_item_position)
+    filter_query = "%7B%22identifier%22%3A%22CLIMATE-MITIGATION-AND-ADAPTATION%22%7D%2C%7B%22identifier%22%3A%22LAND-ECOSYSTEMS%22%7D%2C%7B%22identifier%22%3A%22SPECIES%22%7D%2C%7B%22identifier%22%3A%22FRESHWATER-COASTAL-AND-OCEAN-ECOSYSTEMS%22%7D"
+    "https://www.cbd.int/api/v2019/actions?q=%7B%22actionDetails.actionCategories%22%3A%7B%22%24in%22%3A%5B#{filter_query}%5D%7D%7D&sk=#{first_item_position}&s=%7B%22meta.modifiedOn%22%3A-1%7D&f=%7B%22actionDetails.actionCategories%22%3A1%2C%22actionDetails.orgTypes%22%3A1%2C%22actionDetails.sdgs%22%3A1%2C%22actionDetails.thematicAreas%22%3A1%2C%22actionDetails.operationalAreas%22%3A1%2C%22contacts.country.identifier%22%3A1%2C%22meta%22%3A1%2C%22action.name%22%3A1%2C%22action.description%22%3A1%2C%22action.image%22%3A1%7D&l=10"
+  end
+end

--- a/lib/tasks/import_commitments.rake
+++ b/lib/tasks/import_commitments.rake
@@ -7,34 +7,11 @@ namespace :import do
     Rake::Task['add_country_boundaries'].invoke
     import_csv_file(args.csv_file)
     puts "local Commitments successfully imported"
-    import_from_cbd
+    Services::CbdImporter.new.call
     puts "CBD Commitments successfully imported"
   end
 
   def import_csv_file file
     Commitment.import file
-  end
-
-  def self.import_from_cbd
-    item_number = 0
-    loop do
-      query = "%7B%22identifier%22%3A%22CLIMATE-MITIGATION-AND-ADAPTATION%22%7D%2C%7B%22identifier%22%3A%22LAND-ECOSYSTEMS%22%7D%2C%7B%22identifier%22%3A%22SPECIES%22%7D%2C%7B%22identifier%22%3A%22FRESHWATER-COASTAL-AND-OCEAN-ECOSYSTEMS%22%7D"
-      full_query = "https://www.cbd.int/api/v2019/actions?q=%7B%22actionDetails.actionCategories%22%3A%7B%22%24in%22%3A%5B#{query}%5D%7D%7D&sk=#{item_number}&s=%7B%22meta.modifiedOn%22%3A-1%7D&f=%7B%22actionDetails.actionCategories%22%3A1%2C%22actionDetails.orgTypes%22%3A1%2C%22actionDetails.sdgs%22%3A1%2C%22actionDetails.thematicAreas%22%3A1%2C%22actionDetails.operationalAreas%22%3A1%2C%22contacts.country.identifier%22%3A1%2C%22meta%22%3A1%2C%22action.name%22%3A1%2C%22action.description%22%3A1%2C%22action.image%22%3A1%7D&l=10"
-      response = HTTParty.get(full_query)
-
-      item_number += 10
-      raw_json = JSON.parse(response.body)
-      
-      break if raw_json.empty?
-
-      raw_json.each do |cbd_com|
-        next if cbd_com.nil?
-
-        commitment = Commitment.find_or_initialize_by(cbd_id: cbd_com["_id"])
-        commitment_params = Services::CbdCommitmentHash.new(cbd_com, commitment).call
-        commitment.assign_attributes(commitment_params)
-        commitment.save!
-      end
-    end
   end
 end

--- a/test/models/services/cbd_commitment_hash_test.rb
+++ b/test/models/services/cbd_commitment_hash_test.rb
@@ -34,6 +34,14 @@ class CbdCommitmentHashTest < ActiveSupport::TestCase
           {
             "identifier"=>"LAND-ECOSYSTEMS"
           }
+        ],
+        "operationalAreas"=>[
+          {
+            "identifier"=>"MG"
+          },
+          {
+            "identifier"=>"HU"
+          }
         ]
       },
       "contacts"=>[
@@ -57,7 +65,7 @@ class CbdCommitmentHashTest < ActiveSupport::TestCase
     assert commitment.name == cbd_commitment_json.dig('action', 'name', 'en')
     assert commitment.description == cbd_commitment_json.dig('action', 'description', 'en')
     assert commitment.cbd_id == cbd_commitment_json.dig('_id')
-    assert commitment.countries.first.iso == '--'
     assert commitment.links.first.url == "https://www.cbd.int/action-agenda/contributions/action?action-id=#{cbd_commitment_json.dig('_id')}"
+    assert commitment.countries.pluck(:iso).sort == %w[HU MG]
   end
 end

--- a/test/models/services/cbd_commitment_hash_test.rb
+++ b/test/models/services/cbd_commitment_hash_test.rb
@@ -25,11 +25,6 @@ class CbdCommitmentHashTest < ActiveSupport::TestCase
             "identifier"=>"CBD-SUBJECT-ILC"
           }
         ],
-        "operationalAreas"=>[
-          {
-            "identifier"=>"np"
-          }
-        ],
         "actionCategories"=>[
           {
             "identifier"=>"LAND-ECOSYSTEMS"
@@ -37,10 +32,10 @@ class CbdCommitmentHashTest < ActiveSupport::TestCase
         ],
         "operationalAreas"=>[
           {
-            "identifier"=>"MG"
+            "identifier"=>"mg"
           },
           {
-            "identifier"=>"HU"
+            "identifier"=>"hu"
           }
         ]
       },


### PR DESCRIPTION
Changes the CDB importer to use operationalAreas instead of office location.
also moves the importer logic from the rake task to a new class, so it can be called separately, which will be needed when it's in a cron job.

Testing

Run the importer
Check the cdb commitments have countries linked to them, e.g. ```Commitment.where(commitment_source: 'cbd').map {|x| x.countries.pluck(:name) }```