### PR TITLE
revert: super mega asterisk joy

### DIFF
--- a/config/locales/form/en.yml
+++ b/config/locales/form/en.yml
@@ -72,7 +72,7 @@ en:
           ‘Commitment actions’ are the actions that are taken to achieve objectives.
 
           ‘Area’ refers to the geographical area in which commitment actions take place.
-        required_field_explainer: <p class="form__required-text-explainer">Required mandatory fields to publish commitment*</p>
+        required_field_explainer: <p class="form__required-text-explainer">* Required mandatory fields to publish commitment</p>
         q1:
           title: Enter commitment name
           description: (The name of the activity may describe the commitment actions and place. E.g. ‘Establishment of Cambridge community conserved area’)


### PR DESCRIPTION
The revert didn't come into the PR so I just pushed the revert directly to develop, but this moves the asterisk on the required text explainer, which was what was meant before