### PR TITLE
fix: pre demo fixes

### DIFF
--- a/app/javascript/components/forms/SurveyForm.vue
+++ b/app/javascript/components/forms/SurveyForm.vue
@@ -140,7 +140,25 @@ export default {
       const pages = Array.from(this.survey.pages)
 
       pages.forEach((page, pageIndex) => {
-        const visibleElements = page.elements.filter(element => element.visible)
+        const visibleElements = page.elements.filter(element => {
+          const hiddenNumber = element.hideNumber
+          const hiddenTitle = element.titleLocation === 'hidden'
+          const invisible = !element.visible
+          const notAQuestion = element.getType() === 'html'
+
+          const unnumberedCases = [
+            hiddenTitle,
+            hiddenNumber,
+            invisible,
+            notAQuestion
+          ]
+
+          if (unnumberedCases.some(kase => kase)) {
+            return false
+          }
+
+          return true
+        })
 
         counts[pageIndex] = visibleElements.length
       })

--- a/app/javascript/components/forms/SurveyForm.vue
+++ b/app/javascript/components/forms/SurveyForm.vue
@@ -253,6 +253,8 @@ export default {
         this.appendFileSignedIds(data);
         this.addDestroyKeys(data);
         this.send(data);
+      } else {
+        window.location.replace('/dashboard')
       }
     },
 

--- a/app/javascript/components/forms/SurveyForm.vue
+++ b/app/javascript/components/forms/SurveyForm.vue
@@ -147,8 +147,8 @@ export default {
           const notAQuestion = element.getType() === 'html'
 
           const unnumberedCases = [
-            hiddenTitle,
             hiddenNumber,
+            hiddenTitle,
             invisible,
             notAQuestion
           ]


### PR DESCRIPTION
Fixes:
- exit to dashboard from criteria form
- right-hand question numbering ("n of n"; currently page one of commitments form is showing five, but it should be four - it's counting the required text HTML element as a question)