### PR TITLE
fix: rake task to reassign commitmetns to correct managers and clean …

### DIFF
--- a/app/models/commitments_manager.rb
+++ b/app/models/commitments_manager.rb
@@ -1,0 +1,2 @@
+class CommitmentsManager < ApplicationRecord
+end

--- a/lib/tasks/reassign_commitments_to_correct_managers.rake
+++ b/lib/tasks/reassign_commitments_to_correct_managers.rake
@@ -1,0 +1,15 @@
+desc 'Reassign Commitments to correct managers and remove duplicated manager types'
+task reassign_commitments_to_correct_managers: :environment do
+  reassign_records('Non-profit organisation', 'Non-governmental organisation (NGO)')
+  reassign_records('For-profit organisation', 'For-profit organisation (business and industry)')
+  reassign_records('Joint governance', 'Joint governance (i.e. decisions are made by many)')
+  Manager.find_by(name: 'Collaborative governance (i.e. decisions are made by one group on behalf of many)').update(name: 'Collaborative governance')
+end
+
+def reassign_records(remove_from_string, assign_to_string)
+  remove_from = Manager.find_by(name: remove_from_string)
+  assign_to = Manager.find_by(name: assign_to_string)
+  CommitmentsManager.where(manager_id: remove_from.id).update_all(manager_id: assign_to.id)
+  remove_from.destroy
+  assign_to.update(name: remove_from_string)
+end


### PR DESCRIPTION
…up manager records

We have duplicated manager types with slightly different names on production, because the names changed but the earlier managers were not cleared out. this rake task:

1. reassigns commitments from the duplicate manager to the original manager
2. destroys the duplicate manager
3. changes the name of original manager to that of the duplicate

## Testing:
`rails db:migrate:reset`

### download backup from aws
```aws s3 cp s3://actionagenda.bkp/Daily/db/action_agenda_daily/2022.06.07.01.30.02/action_agenda_daily.tar aa.tar```

### unzip then unzip again, go to directory where PostgreSQL.sql has been unzipped to

`psql -U :your_user -d aa_development -f PostgreSQL.sql`

### i get postgres errors but data imports fine

### in console before running rake task:
`old_ngo_count = CommitmentsManager.where(manager_id: Manager.where(name: ['Non-profit organisation', 'Non-governmental organisation (NGO)']).pluck(:id)).count`
`old_for_profit_count = CommitmentsManager.where(manager_id: Manager.where(name: ['For-profit organisation', 'For-profit organisation (business and industry)']).pluck(:id)).count`
`old_joint_governace_count = CommitmentsManager.where(manager_id: Manager.where(name: ['Joint governance', 'Joint governance (i.e. decisions are made by many)']).pluck(:id)).count`

### after rake task
`Manager.find_by(name: 'Non-profit organisation').commitments.count == old_ngo_count`
`Manager.find_by(name: 'For-profit organisation').commitments.count == old_for_profit_count`
`Manager.find_by(name: 'Joint governance').commitments.count == old_joint_governace_count`

### run importer
`Services::CbdImporter.new.call`

### check this is still the same
`Manager.pluck(:name)`

### check the ui to make sure everything is still ok