### PR TITLE
fix: view commitments error

### DIFF
--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -207,7 +207,7 @@ class Commitment < ApplicationRecord
     params.compact
   end
 
-  def self.run_query(_page, where_params)
+  def self.run_query(where_params)
     # WARNING! Do not remove the 'published' scope, because this will show unpublished Commitments
     # people might not want public and CBD commitments we've chosen not to display.
     Commitment.published


### PR DESCRIPTION
Currently clicking on "View commitments" from a country on the map leads to an error. It looks like somewhere along the way the number of arguments being passed into a method changed but the parameters didn't (perhaps it was a dodgy merge). This removes the parameter corresponding to the unused argument (the method isn't used anywhere else, so we shouldn't need that extra parameter)